### PR TITLE
[Feature][Zeta]support async save wal to storage

### DIFF
--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-api/src/main/java/org/apache/seatunnel/engine/imap/storage/api/common/ImapStorageThreadFactory.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-api/src/main/java/org/apache/seatunnel/engine/imap/storage/api/common/ImapStorageThreadFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.seatunnel.engine.imap.storage.api.common;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ImapStorageThreadFactory implements ThreadFactory {
+    private final AtomicInteger poolNumber = new AtomicInteger(1);
+    private final ThreadGroup group;
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+    private final String namePrefix;
+
+    public ImapStorageThreadFactory() {
+        SecurityManager s = System.getSecurityManager();
+        group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        namePrefix = "Imap-StorageThread-" + poolNumber.getAndIncrement() + "-thread-";
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        Thread thread = new Thread(group, runnable, namePrefix + threadNumber.getAndIncrement(), 0);
+        if (thread.isDaemon()) {
+            thread.setDaemon(false);
+        }
+        if (thread.getPriority() != Thread.NORM_PRIORITY) {
+            thread.setPriority(Thread.NORM_PRIORITY);
+        }
+        return thread;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALSyncType.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALSyncType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.seatunnel.engine.imap.storage.file.common;
+
+public enum WALSyncType {
+    SYNC,
+    ASYNC
+}

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/common/WALWriter.java
@@ -20,6 +20,7 @@
 
 package org.apache.seatunnel.engine.imap.storage.file.common;
 
+import org.apache.seatunnel.engine.imap.storage.api.common.ImapStorageThreadFactory;
 import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
 import org.apache.seatunnel.engine.imap.storage.file.config.FileConfiguration;
 import org.apache.seatunnel.engine.imap.storage.file.wal.DiscoveryWalFileFactory;
@@ -29,29 +30,85 @@ import org.apache.seatunnel.engine.serializer.api.Serializer;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
 public class WALWriter implements AutoCloseable {
 
     IFileWriter writer;
 
+    private ExecutorService walWriterService;
+
+    Future<?> writeTaskFuture;
+
+    private static final int DEFAULT_THREAD_POOL_MIN_SIZE =
+            Runtime.getRuntime().availableProcessors() * 2 + 1;
+
+    private static final int DEFAULT_THREAD_POOL_MAX_SIZE =
+            Runtime.getRuntime().availableProcessors() * 4 + 1;
+
+    private static final int DEFAULT_THREAD_POOL_QUENE_SIZE = 1024;
+
+    private final WALSyncType walSyncType;
+
     public WALWriter(
             FileSystem fs,
             FileConfiguration fileConfiguration,
+            WALSyncType walSyncType,
             Path parentPath,
             Serializer serializer)
             throws IOException {
         this.writer = DiscoveryWalFileFactory.getWriter(fileConfiguration.getName());
         this.writer.setBlockSize(fileConfiguration.getConfiguration().getBlockSize());
         this.writer.initialize(fs, parentPath, serializer);
+        this.walSyncType = walSyncType;
+        if (WALSyncType.ASYNC == walSyncType) {
+            this.walWriterService =
+                    new ThreadPoolExecutor(
+                            DEFAULT_THREAD_POOL_MIN_SIZE,
+                            DEFAULT_THREAD_POOL_MAX_SIZE,
+                            0L,
+                            TimeUnit.MILLISECONDS,
+                            new LinkedBlockingQueue<>(DEFAULT_THREAD_POOL_QUENE_SIZE),
+                            new ImapStorageThreadFactory());
+        }
     }
 
     public void write(IMapFileData data) throws IOException {
-        this.writer.write(data);
+
+        switch (walSyncType) {
+            case SYNC:
+                this.writer.write(data);
+                return;
+            case ASYNC:
+                writeTaskFuture =
+                        this.walWriterService.submit(
+                                () -> {
+                                    try {
+                                        this.writer.write(data);
+                                    } catch (Exception e) {
+                                        log.error(String.format("store imap failed : %s", data), e);
+                                    }
+                                });
+                return;
+        }
     }
 
     @Override
     public void close() throws Exception {
+        if (WALSyncType.ASYNC == walSyncType && writeTaskFuture != null) {
+            writeTaskFuture.cancel(false);
+            if (walWriterService != null) {
+                walWriterService.shutdown();
+            }
+        }
         this.writer.close();
     }
 }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/disruptor/WALDisruptor.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/disruptor/WALDisruptor.java
@@ -22,6 +22,7 @@ package org.apache.seatunnel.engine.imap.storage.file.disruptor;
 
 import org.apache.seatunnel.engine.imap.storage.api.exception.IMapStorageException;
 import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
+import org.apache.seatunnel.engine.imap.storage.file.common.WALSyncType;
 import org.apache.seatunnel.engine.imap.storage.file.config.FileConfiguration;
 import org.apache.seatunnel.engine.serializer.api.Serializer;
 
@@ -62,6 +63,7 @@ public class WALDisruptor implements Closeable {
     public WALDisruptor(
             FileSystem fs,
             FileConfiguration fileConfiguration,
+            WALSyncType walSyncType,
             String parentPath,
             Serializer serializer) {
         // todo should support multi thread producer
@@ -73,9 +75,8 @@ public class WALDisruptor implements Closeable {
                         threadFactory,
                         ProducerType.SINGLE,
                         new BlockingWaitStrategy());
-
         disruptor.handleEventsWithWorkerPool(
-                new WALWorkHandler(fs, fileConfiguration, parentPath, serializer));
+                new WALWorkHandler(fs, fileConfiguration, walSyncType, parentPath, serializer));
 
         disruptor.start();
     }

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/disruptor/WALWorkHandler.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/disruptor/WALWorkHandler.java
@@ -22,6 +22,7 @@ package org.apache.seatunnel.engine.imap.storage.file.disruptor;
 
 import org.apache.seatunnel.engine.imap.storage.api.exception.IMapStorageException;
 import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
+import org.apache.seatunnel.engine.imap.storage.file.common.WALSyncType;
 import org.apache.seatunnel.engine.imap.storage.file.common.WALWriter;
 import org.apache.seatunnel.engine.imap.storage.file.config.FileConfiguration;
 import org.apache.seatunnel.engine.imap.storage.file.future.RequestFutureCache;
@@ -44,10 +45,13 @@ public class WALWorkHandler implements WorkHandler<FileWALEvent> {
     public WALWorkHandler(
             FileSystem fs,
             FileConfiguration fileConfiguration,
+            WALSyncType walSyncType,
             String parentPath,
             Serializer serializer) {
         try {
-            writer = new WALWriter(fs, fileConfiguration, new Path(parentPath), serializer);
+            writer =
+                    new WALWriter(
+                            fs, fileConfiguration, walSyncType, new Path(parentPath), serializer);
         } catch (IOException e) {
             throw new IMapStorageException(
                     e, "create new current writer failed, parent path is %s", parentPath);

--- a/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
+++ b/seatunnel-engine/seatunnel-engine-storage/imap-storage-plugins/imap-storage-file/src/main/java/org/apache/seatunnel/engine/imap/storage/file/wal/writer/CloudWriter.java
@@ -73,7 +73,6 @@ public abstract class CloudWriter implements IFileWriter<IMapFileData> {
         }
     }
 
-    // TODO Synchronous write, asynchronous write can be added in the future
     @Override
     public void write(IMapFileData data) throws IOException {
         byte[] bytes = serializer.serialize(data);


### PR DESCRIPTION
Purpose of this pull request

In addition to the sync wal write mechanism currently supported by Seatunnel, this PR provides an async wal write mechanism that does not need to wait for the WAL to be persisted, thus reducing write latency.

Does this PR introduce any user-facing change?

yes, adds a new configuration: `wal.sync.method` 


How was this patch tested?

add new test.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).