### PR TITLE
[Fix][E2E] Disable HDFS  in CI

### DIFF
--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/MongodbSource.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/MongodbSource.java
@@ -78,7 +78,7 @@ public class MongodbSource
     public SourceReader<SeaTunnelRow, MongoSplit> createReader(SourceReader.Context readerContext) {
         return new MongodbReader(
                 readerContext,
-                crateClientProvider(options),
+                createClientProvider(options),
                 createDeserializer(options, catalogTable.getSeaTunnelRowType()),
                 createMongodbReadOptions(options));
     }
@@ -86,7 +86,7 @@ public class MongodbSource
     @Override
     public SourceSplitEnumerator<MongoSplit, ArrayList<MongoSplit>> createEnumerator(
             SourceSplitEnumerator.Context<MongoSplit> enumeratorContext) {
-        MongodbClientProvider clientProvider = crateClientProvider(options);
+        MongodbClientProvider clientProvider = createClientProvider(options);
         return new MongodbSplitEnumerator(
                 enumeratorContext, clientProvider, createSplitStrategy(options, clientProvider));
     }
@@ -95,7 +95,7 @@ public class MongodbSource
     public SourceSplitEnumerator<MongoSplit, ArrayList<MongoSplit>> restoreEnumerator(
             SourceSplitEnumerator.Context<MongoSplit> enumeratorContext,
             ArrayList<MongoSplit> checkpointState) {
-        MongodbClientProvider clientProvider = crateClientProvider(options);
+        MongodbClientProvider clientProvider = createClientProvider(options);
         return new MongodbSplitEnumerator(
                 enumeratorContext,
                 clientProvider,
@@ -103,7 +103,7 @@ public class MongodbSource
                 checkpointState);
     }
 
-    private MongodbClientProvider crateClientProvider(ReadonlyConfig config) {
+    private MongodbClientProvider createClientProvider(ReadonlyConfig config) {
         return MongodbCollectionProvider.builder()
                 .connectionString(config.get(MongodbConfig.URI))
                 .database(config.get(MongodbConfig.DATABASE))

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-hive-e2e/src/test/java/org/apache/seatunnel/e2e/connector/hive/HiveIT.java
@@ -228,6 +228,8 @@ public class HiveIT extends TestSuiteBase implements TestResource {
     }
 
     @TestTemplate
+    @Disabled(
+            "[HDFS/COS/OSS/S3] is not available in CI, if you want to run this test, please set up your own environment in the test case file, hadoop_hive_conf_path_local and ip below}")
     public void testFakeSinkHiveOnHDFS(TestContainer container) throws Exception {
         executeJob(container, "/fake_to_hive_on_hdfs.conf", "/hive_on_hdfs_to_assert.conf");
     }


### PR DESCRIPTION

### Purpose of this pull request

[HDFS/COS/OSS/S3] is not available in CI, if you want to run this test, please set up your own environment in the test case file, hadoop_hive_conf_path_local and ip below

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
exist tests

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).