### PR TITLE
[Fix][Connector-V2] Add Filter for Partitions to Prevent Blocking in KafkaConsumer

### DIFF
--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
@@ -311,13 +311,17 @@ public class KafkaSourceSplitEnumerator
                         .flatMap(
                                 t ->
                                         t.partitions().stream()
-                                                .filter(partitionInfo -> {
-                                                    if (partitionInfo.leader() == null) {
-                                                        log.warn("Partition {} of topic {} has no leader.", partitionInfo.partition(), t.name());
-                                                        return false;
-                                                    }
-                                                    return true;
-                                                })
+                                                .filter(
+                                                        partitionInfo -> {
+                                                            if (partitionInfo.leader() == null) {
+                                                                log.warn(
+                                                                        "Partition {} of topic {} has no leader.",
+                                                                        partitionInfo.partition(),
+                                                                        t.name());
+                                                                return false;
+                                                            }
+                                                            return true;
+                                                        })
                                                 .map(
                                                         p ->
                                                                 new TopicPartition(

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
@@ -311,9 +311,13 @@ public class KafkaSourceSplitEnumerator
                         .flatMap(
                                 t ->
                                         t.partitions().stream()
-                                                .filter(
-                                                        partitionInfo ->
-                                                                partitionInfo.leader() != null)
+                                                .filter(partitionInfo -> {
+                                                    if (partitionInfo.leader() == null) {
+                                                        log.warn("Partition {} of topic {} has no leader.", partitionInfo.partition(), t.name());
+                                                        return false;
+                                                    }
+                                                    return true;
+                                                })
                                                 .map(
                                                         p ->
                                                                 new TopicPartition(

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
@@ -307,10 +307,13 @@ public class KafkaSourceSplitEnumerator
         }
         log.info("Discovered topics: {}", topics);
         Collection<TopicPartition> partitions =
-                adminClient.describeTopics(topics).all().get().values().stream()
+                adminClient.describeTopics(topics).allTopicNames().get().values().stream()
                         .flatMap(
                                 t ->
                                         t.partitions().stream()
+                                                .filter(
+                                                        partitionInfo ->
+                                                                partitionInfo.leader() != null)
                                                 .map(
                                                         p ->
                                                                 new TopicPartition(

--- a/seatunnel-connectors-v2/connector-kafka/src/test/java/org/apache/kafka/clients/admin/KafkaSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/test/java/org/apache/kafka/clients/admin/KafkaSourceSplitEnumeratorTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.connectors.seatunnel.kafka.source.KafkaSourceSplit;
 import org.apache.seatunnel.connectors.seatunnel.kafka.source.KafkaSourceSplitEnumerator;
 
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 
@@ -74,7 +75,9 @@ class KafkaSourceSplitEnumeratorTest {
                                                                 Collections.singletonList(
                                                                         new TopicPartitionInfo(
                                                                                 0,
-                                                                                null,
+                                                                                new Node(
+                                                                                        2, "",
+                                                                                        18080),
                                                                                 Collections
                                                                                         .emptyList(),
                                                                                 Collections


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

There may be an issue in the Kafka cluster where the disks containing a partition go offline simultaneously, resulting in the partition's leader being -1. When leader=-1, Kafka APIs like KafkaConsumer.position() will block. Therefore, we should filter out partitions with leader=-1.

![image](https://github.com/user-attachments/assets/bf49a699-9b96-45f5-8f09-412b4935e8ea)



### Does this PR introduce _any_ user-facing change?

no


### How was this patch tested?

exist tests


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
* [ ] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).