### PR TITLE
[Fix][Connector-V2] Remove pre-checks and rely on save_mode_create_template options for Doris table creation

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/catalog/DorisCatalog.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/catalog/DorisCatalog.java
@@ -396,21 +396,6 @@ public class DorisCatalog implements Catalog {
     @Override
     public void createTable(TablePath tablePath, CatalogTable table, boolean ignoreIfExists)
             throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
-
-        if (!databaseExists(tablePath.getDatabaseName())) {
-            throw new DatabaseNotExistException(catalogName, tablePath.getDatabaseName());
-        }
-
-        boolean tableExists = tableExists(tablePath);
-        if (ignoreIfExists && tableExists) {
-            LOG.info("table {} is exists, skip create", tablePath.getFullName());
-            return;
-        }
-
-        if (tableExists) {
-            throw new TableAlreadyExistException(catalogName, tablePath);
-        }
-
         String stmt =
                 DorisCatalogUtil.getCreateTableStatement(
                         createTableTemplate, tablePath, table, typeConverter);

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisCatalogIT.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.e2e.connector.doris;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.sink.SaveModeHandler;
+import org.apache.seatunnel.api.sink.SaveModePlaceHolder;
 import org.apache.seatunnel.api.sink.SupportSaveMode;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -28,6 +29,7 @@ import org.apache.seatunnel.api.table.catalog.PrimaryKey;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.catalog.exception.CatalogException;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.api.table.type.BasicType;
@@ -84,7 +86,7 @@ public class DorisCatalogIT extends AbstractDorisIT {
     @BeforeAll
     public void init() {
         initCatalogFactory();
-        initCatalog();
+        initDefaultCatalog();
     }
 
     private void initCatalogFactory() {
@@ -93,26 +95,66 @@ public class DorisCatalogIT extends AbstractDorisIT {
         }
     }
 
-    private void initCatalog() {
-        String catalogName = "doris";
+    private void initDefaultCatalog() {
         String frontEndNodes = container.getHost() + ":" + HTTP_PORT;
+        Map<String, Object> map = new HashMap<>();
+        map.put(DorisBaseOptions.FENODES.key(), frontEndNodes);
+        map.put(DorisBaseOptions.QUERY_PORT.key(), QUERY_PORT);
+        map.put(DorisBaseOptions.USERNAME.key(), USERNAME);
+        map.put(DorisBaseOptions.PASSWORD.key(), PASSWORD);
+        initCatalog(map);
+    }
+
+    private void initCatalog(Map<String, Object> map) {
+        close();
+        String catalogName = "doris";
         factory = new DorisCatalogFactory();
+        catalog = (DorisCatalog) factory.createCatalog(catalogName, ReadonlyConfig.fromMap(map));
+        catalog.open();
+        catalog.createDatabase(tablePath, false);
+    }
+
+    private void initCatalogWithSaveModeCreateTemplate() {
+        String frontEndNodes = container.getHost() + ":" + HTTP_PORT;
+        String createTableWithCreateTemplate =
+                "CREATE TABLE `"
+                        + SaveModePlaceHolder.DATABASE.getPlaceHolder()
+                        + "`.`"
+                        + SaveModePlaceHolder.TABLE.getPlaceHolder()
+                        + "` (\n"
+                        + SaveModePlaceHolder.ROWTYPE_PRIMARY_KEY.getPlaceHolder()
+                        + ",\n"
+                        + SaveModePlaceHolder.ROWTYPE_FIELDS.getPlaceHolder()
+                        + "\n"
+                        + ") ENGINE=OLAP\n"
+                        + " UNIQUE KEY ("
+                        + SaveModePlaceHolder.ROWTYPE_PRIMARY_KEY.getPlaceHolder()
+                        + ")\n"
+                        + "COMMENT '"
+                        + SaveModePlaceHolder.COMMENT.getPlaceHolder()
+                        + "'\n"
+                        + "DISTRIBUTED BY HASH ("
+                        + SaveModePlaceHolder.ROWTYPE_PRIMARY_KEY.getPlaceHolder()
+                        + ")\n "
+                        + "PROPERTIES (\n"
+                        + "\"replication_allocation\" = \"tag.location.default: 1\",\n"
+                        + "\"in_memory\" = \"false\",\n"
+                        + "\"storage_format\" = \"V2\",\n"
+                        + "\"disable_auto_compaction\" = \"false\"\n"
+                        + ")";
 
         Map<String, Object> map = new HashMap<>();
         map.put(DorisBaseOptions.FENODES.key(), frontEndNodes);
         map.put(DorisBaseOptions.QUERY_PORT.key(), QUERY_PORT);
         map.put(DorisBaseOptions.USERNAME.key(), USERNAME);
         map.put(DorisBaseOptions.PASSWORD.key(), PASSWORD);
-
-        catalog = (DorisCatalog) factory.createCatalog(catalogName, ReadonlyConfig.fromMap(map));
-
-        catalog.open();
-        catalog.createDatabase(tablePath, false);
+        map.put(DorisSinkOptions.SAVE_MODE_CREATE_TEMPLATE.key(), createTableWithCreateTemplate);
+        initCatalog(map);
     }
 
     @Test
     void factoryIdentifier() {
-        Assertions.assertEquals(factory.factoryIdentifier(), "Doris");
+        Assertions.assertEquals("Doris", factory.factoryIdentifier());
     }
 
     @Test
@@ -144,13 +186,26 @@ public class DorisCatalogIT extends AbstractDorisIT {
         List<String> tables = catalog.listTables(tablePath.getDatabaseName());
         Assertions.assertFalse(tables.isEmpty());
 
+        // Whether the ignoreIfExists flag should depend on the SAVE_MODE_CREATE_TEMPLATE SQL script
+        // when creating tables in Doris Catalog
+        Assertions.assertDoesNotThrow(() -> catalog.createTable(tablePath, catalogTable, false));
+        Assertions.assertDoesNotThrow(() -> catalog.createTable(tablePath, catalogTable, true));
+        initCatalogWithSaveModeCreateTemplate();
+        catalog.createTable(tablePath, catalogTable, false);
+        Assertions.assertTrue(catalog.tableExists(tablePath));
+        Assertions.assertThrows(
+                CatalogException.class, () -> catalog.createTable(tablePath, catalogTable, false));
+        Assertions.assertThrows(
+                CatalogException.class, () -> catalog.createTable(tablePath, catalogTable, true));
+
         catalog.dropTable(tablePath, false);
         Assertions.assertFalse(catalog.tableExists(tablePath));
-
         if (dbCreated) {
             catalog.dropDatabase(tablePath, false);
             Assertions.assertFalse(catalog.databaseExists(tablePath.getDatabaseName()));
         }
+
+        initDefaultCatalog();
     }
 
     @Test
@@ -333,6 +388,7 @@ public class DorisCatalogIT extends AbstractDorisIT {
     @AfterAll
     public void close() {
         if (catalog != null) {
+            catalog.dropDatabase(tablePath, false);
             catalog.close();
         }
     }


### PR DESCRIPTION
### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

Whether the ignoreIfExists flag should depend on the SAVE_MODE_CREATE_TEMPLATE SQL script, when creating tables in Doris Catalog

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add tests

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)